### PR TITLE
refactor: patchAdmin 속도 튜닝

### DIFF
--- a/src/main/kotlin/CoBo/SharedRoutine/global/repository/Custom/ParticipationRepositoryCustom.kt
+++ b/src/main/kotlin/CoBo/SharedRoutine/global/repository/Custom/ParticipationRepositoryCustom.kt
@@ -1,0 +1,6 @@
+package CoBo.SharedRoutine.global.repository.Custom
+
+interface ParticipationRepositoryCustom {
+
+    fun existsByUserIdAndRoutineIdByQueryDsl(userId: Int, routineId: Int):Boolean
+}

--- a/src/main/kotlin/CoBo/SharedRoutine/global/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/CoBo/SharedRoutine/global/repository/ParticipationRepository.kt
@@ -3,12 +3,13 @@ package CoBo.SharedRoutine.global.repository
 import CoBo.SharedRoutine.global.data.entity.Participation
 import CoBo.SharedRoutine.global.data.entity.Routine
 import CoBo.SharedRoutine.global.data.entity.User
+import CoBo.SharedRoutine.global.repository.Custom.ParticipationRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
-interface ParticipationRepository: JpaRepository<Participation, Int>{
+interface ParticipationRepository: JpaRepository<Participation, Int>, ParticipationRepositoryCustom{
 
     fun existsByUserAndRoutine(user: User, routine: Routine): Boolean
     fun findByUserAndRoutine(user: User, routine: Routine): Optional<Participation>

--- a/src/main/kotlin/CoBo/SharedRoutine/global/repository/QueryDsl/ParticipationRepositoryImpl.kt
+++ b/src/main/kotlin/CoBo/SharedRoutine/global/repository/QueryDsl/ParticipationRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package CoBo.SharedRoutine.global.repository.QueryDsl
+
+import CoBo.SharedRoutine.global.data.entity.QParticipation.participation
+import CoBo.SharedRoutine.global.repository.Custom.ParticipationRepositoryCustom
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class ParticipationRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory): ParticipationRepositoryCustom {
+
+    override fun existsByUserIdAndRoutineIdByQueryDsl(userId: Int, routineId: Int): Boolean {
+        return jpaQueryFactory
+            .select(participation)
+            .from(participation)
+            .leftJoin(participation.user)
+            .where(
+                participation.routine.id.eq(routineId),
+                participation.user.kakaoId.eq(userId)
+            ).fetchFirst() != null
+    }
+
+}


### PR DESCRIPTION
- participationRepository에 existsByUserIdAndRoutineIdByQueryDsl 메서드 생성
- 해당 API를 리액티브하게 변경